### PR TITLE
Fix Bytes.or(Bytes bytes) (fixes #2)

### DIFF
--- a/src/main/java/at/favre/lib/bytes/Bytes.java
+++ b/src/main/java/at/favre/lib/bytes/Bytes.java
@@ -744,7 +744,7 @@ public class Bytes implements Comparable<Bytes>, Serializable, Iterable<Byte> {
      * @see <a href="https://en.wikipedia.org/wiki/Bitwise_operation#OR">Bitwise operators: OR</a>
      */
     public Bytes or(Bytes bytes) {
-        return and(bytes.internalArray());
+        return or(bytes.internalArray());
     }
 
     /**


### PR DESCRIPTION
This method previously called `this.and(bytes.internalArray()`, but it should be `this.or(bytes.internalArray()`.