### PR TITLE
Remove println call from library code

### DIFF
--- a/src/main/java/at/favre/lib/bytes/BinaryToTextEncoding.java
+++ b/src/main/java/at/favre/lib/bytes/BinaryToTextEncoding.java
@@ -155,7 +155,6 @@ public interface BinaryToTextEncoding {
 
         @Override
         public String encode(byte[] array, ByteOrder byteOrder) {
-            System.out.println("max length " + maxLength(array, radix));
             return new BigInteger(1, (byteOrder == ByteOrder.BIG_ENDIAN) ? array : Bytes.from(array).reverse().array()).toString(radix);
         }
 


### PR DESCRIPTION
Previously, a `max length` message was printed any time you called `Bytes.encode(byte[], byteOrder)`.