### PR TITLE
Allocate methods that return MutableBytes

### DIFF
--- a/src/main/java/at/favre/lib/bytes/MutableBytes.java
+++ b/src/main/java/at/favre/lib/bytes/MutableBytes.java
@@ -38,6 +38,27 @@ public final class MutableBytes extends Bytes implements AutoCloseable {
         super(byteArray, byteOrder, new Factory());
     }
 
+    /**
+     * Creates a new instance with an empty array filled with zeros.
+     *
+     * @param length of the internal array
+     * @return new instance
+     */
+    public static MutableBytes allocate(int length) {
+        return allocate(length, (byte) 0);
+    }
+
+    /**
+     * Creates a new instance with an empty array filled with given defaultValue
+     *
+     * @param length       of the internal array
+     * @param defaultValue to fill with
+     * @return new instance
+     */
+    public static MutableBytes allocate(int length, byte defaultValue) {
+        return Bytes.allocate(length, defaultValue).mutable();
+    }
+
     @Override
     public boolean isMutable() {
         return true;


### PR DESCRIPTION
Currently creating new MutableBytes require calling.mutable().
MutableBytes data = MutableBytes.allocate(someSize).mutable(); 
Calling mutable() on MutableBytes looks counter-intuitive.

With this change, simpler version could be used:
MutableBytes data = MutableBytes.allocate(someSize); 

