### PR TITLE
Overwrite-methods that take Bytes as parameters. Tests for IndexOutOf…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Releases
 
+## Unreleased
+
+* adds overwrite method to Bytes
+* adds tests to NullPointerException and IndexOutOfBoundsException
+
 ## v1.0.0
 
 * add `append()` method supporting multiple byte arrays #26

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.11</version>
+                        <version>8.18</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/main/java/at/favre/lib/bytes/MutableBytes.java
+++ b/src/main/java/at/favre/lib/bytes/MutableBytes.java
@@ -75,6 +75,10 @@ public final class MutableBytes extends Bytes implements AutoCloseable {
         return overwrite(newArray, 0);
     }
 
+    public MutableBytes overwrite(Bytes newArray) {
+        return overwrite(newArray, 0);
+    }
+
     /**
      * Uses given array to overwrite internal array.
      *
@@ -86,6 +90,12 @@ public final class MutableBytes extends Bytes implements AutoCloseable {
     public MutableBytes overwrite(byte[] newArray, int offsetInternalArray) {
         Objects.requireNonNull(newArray, "must provide non-null array as source");
         System.arraycopy(newArray, 0, internalArray(), offsetInternalArray, newArray.length);
+        return this;
+    }
+
+    public MutableBytes overwrite(Bytes newBytes, int offsetInternalArray) {
+        Objects.requireNonNull(newBytes, "must provide non-null array as source");
+        System.arraycopy(newBytes.array(), 0, internalArray(), offsetInternalArray, newBytes.array().length);
         return this;
     }
 

--- a/src/main/java/at/favre/lib/bytes/MutableBytes.java
+++ b/src/main/java/at/favre/lib/bytes/MutableBytes.java
@@ -72,11 +72,13 @@ public final class MutableBytes extends Bytes implements AutoCloseable {
      * @throws IndexOutOfBoundsException if newArray.length &gt; internal length
      */
     public MutableBytes overwrite(byte[] newArray) {
+
         return overwrite(newArray, 0);
     }
 
-    public MutableBytes overwrite(Bytes newArray) {
-        return overwrite(newArray, 0);
+    public MutableBytes overwrite(Bytes newBytes) {
+
+        return overwrite(newBytes, 0);
     }
 
     /**
@@ -94,9 +96,7 @@ public final class MutableBytes extends Bytes implements AutoCloseable {
     }
 
     public MutableBytes overwrite(Bytes newBytes, int offsetInternalArray) {
-        Objects.requireNonNull(newBytes, "must provide non-null array as source");
-        System.arraycopy(newBytes.array(), 0, internalArray(), offsetInternalArray, newBytes.array().length);
-        return this;
+        return overwrite(Objects.requireNonNull(newBytes, "must provide non-null array as source").array(), offsetInternalArray);
     }
 
     /**

--- a/src/test/java/at/favre/lib/bytes/MutableBytesTest.java
+++ b/src/test/java/at/favre/lib/bytes/MutableBytesTest.java
@@ -73,19 +73,39 @@ public class MutableBytesTest extends ABytesTest {
         assertArrayEquals(c.array(), Bytes.from(b).append(d).array());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void overwriteTooBigArrayShouldThrowException() {
         MutableBytes b = fromAndTest(example_bytes_seven).mutable();
-        b.overwrite(new byte[]{(byte) 0xAA, 0x30}, b.length() - 1);
+        try {
+            b.overwrite(new byte[]{(byte) 0xAA, 0x30}, b.length());
+            fail();
+        } catch(IndexOutOfBoundsException ignored) {}
 
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
+    public void overwriteTooBigBytesShouldThrowException() {
+        MutableBytes b = fromAndTest(example_bytes_seven).mutable();
+        System.out.println(b);
+        try {
+            b.overwrite(Bytes.from((byte) 0xAA, 0x30), b.length());
+            fail();
+        } catch(IndexOutOfBoundsException ignored) {}
+
+    }
+
+    @Test
     public void overwriteNullArrayShouldThrowException() {
         MutableBytes nonsense = null;
-        MutableBytes b = fromAndTest(example_bytes_seven).mutable();
-        b.overwrite(nonsense.array());
+        try{
+            MutableBytes b = fromAndTest(example_bytes_seven).mutable();
+            b.overwrite(nonsense);
+            fail();
+        } catch (NullPointerException ignored){}
+
+
     }
+
 
     @Test
     public void fill() {
@@ -208,4 +228,5 @@ public class MutableBytesTest extends ABytesTest {
         assertArrayNotEquals(new byte[16], leak.array());
 
     }
+
 }

--- a/src/test/java/at/favre/lib/bytes/MutableBytesTest.java
+++ b/src/test/java/at/favre/lib/bytes/MutableBytesTest.java
@@ -64,6 +64,30 @@ public class MutableBytesTest extends ABytesTest {
     }
 
     @Test
+    public void overwriteBytes() {
+        MutableBytes a = fromAndTest(example_bytes_seven).mutable();
+        MutableBytes b = Bytes.from((byte)0).mutable();
+        MutableBytes c = a.overwrite(b, 0).mutable();
+        MutableBytes d = Bytes.wrap(a).copy(1, a.array().length-1).mutable();
+
+        assertArrayEquals(c.array(), Bytes.from(b).append(d).array());
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void overwriteTooBigArrayShouldThrowException() {
+        MutableBytes b = fromAndTest(example_bytes_seven).mutable();
+        b.overwrite(new byte[]{(byte) 0xAA, 0x30}, b.length() - 1);
+
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void overwriteNullArrayShouldThrowException() {
+        MutableBytes nonsense = null;
+        MutableBytes b = fromAndTest(example_bytes_seven).mutable();
+        b.overwrite(nonsense.array());
+    }
+
+    @Test
     public void fill() {
         MutableBytes b = fromAndTest(example_bytes_seven).mutable();
         assertSame(b, b.fill((byte) 0));


### PR DESCRIPTION
…Bounds-exception when overwritten array exceeds the original size and NullPointerException when the array used to overwrite is null