### PR TITLE
Fix Bytes.bitAt to respect byte order

### DIFF
--- a/src/main/java/at/favre/lib/bytes/Bytes.java
+++ b/src/main/java/at/favre/lib/bytes/Bytes.java
@@ -1338,7 +1338,11 @@ public class Bytes implements Comparable<Bytes>, Serializable, Iterable<Byte> {
      */
     public boolean bitAt(int bitIndex) {
         Util.Validation.checkIndexBounds(lengthBit(), bitIndex, 1, "bit");
-        return ((byteAt(length() - 1 - (bitIndex / 8)) >>> bitIndex % 8) & 1) != 0;
+        if (byteOrder == ByteOrder.BIG_ENDIAN) {
+            return ((byteAt(length() - 1 - (bitIndex / 8)) >>> bitIndex % 8) & 1) != 0;
+        } else {
+            return ((byteAt(bitIndex / 8) >>> bitIndex % 8) & 1) != 0;
+        }
     }
 
     /**

--- a/src/test/java/at/favre/lib/bytes/BytesMiscTest.java
+++ b/src/test/java/at/favre/lib/bytes/BytesMiscTest.java
@@ -272,6 +272,12 @@ public class BytesMiscTest extends ABytesTest {
             fail();
         } catch (IndexOutOfBoundsException ignored) {
         }
+
+        Bytes bytes = Bytes.wrap(new byte[]{1, 0, 2, 0}).byteOrder(ByteOrder.LITTLE_ENDIAN);
+        assertTrue(bytes.bitAt(0));
+        assertTrue(bytes.bitAt(17));
+        assertFalse(bytes.bitAt(8));
+        assertFalse(bytes.bitAt(31));
     }
 
     @Test


### PR DESCRIPTION
Closes #39. bitAt now checks byte order before locating the desired
bit.