### PR TITLE
Correct Checkstyle clause in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 We ❤ pull requests from everyone.
 
-If possible proof features and bug fixes with unit tests.
+If possible to proof features and bug fixes with unit tests.
 This repo validates against checkstyle (import the xml found in the root to your IDE if possible)
 
 To run the tests (and checkstyle):
 
 ```shell
-mvn test
+mvn verify
 ```
 
 Tests are automatically run against branches and pull requests

--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ Use the Maven wrapper to create a jar including all dependencies
 ### Checkstyle Config File
 
 This project uses my [`common-parent`](https://github.com/patrickfav/mvn-common-parent) which centralized a lot of
-the plugin versions aswell as providing the checkstyle config rules. Specifically they are maintained in [`checkstyle-config`](https://github.com/patrickfav/checkstyle-config). Locally the files will be copied after you `mvnw install` into your `target` folder and is called
+the plugin versions as well as providing the checkstyle config rules. Specifically they are maintained in [`checkstyle-config`](https://github.com/patrickfav/checkstyle-config). Locally the files will be copied after you `mvnw install` into your `target` folder and is called
 `target/checkstyle-checker.xml`. So if you use a plugin for your IDE, use this file as your local configuration.
 
 ## Tech Stack


### PR DESCRIPTION
Hi Patrick,

Correct me if I'm wrong but it looks like `checkstyle:check` binds to Maven's `verify` phase by default ([docs](https://maven.apache.org/plugins/maven-checkstyle-plugin/check-mojo.html)). Thus it seems worth it to adjust the docs since `mvn test` is not going to run Checkstyle.

If `mvn test` is indeed what you had in mind, guess you could change the `common-parent` POM to bind Checkstyle to another phase but this could have ramifications in other projects only you are aware of as the POM maintainer. 

The purpose of this PR is just to attract attention to the wording in docs, feel free to discard it.