### PR TITLE
Add toIndex versions for indexOf()

### DIFF
--- a/src/main/java/at/favre/lib/bytes/Bytes.java
+++ b/src/main/java/at/favre/lib/bytes/Bytes.java
@@ -1278,6 +1278,20 @@ public class Bytes implements Comparable<Bytes>, Serializable, Iterable<Byte> {
     }
 
     /**
+     * Returns the index of the first appearance of the value {@code target} in
+     * {@code array} from given start index 'fromIndex' to given end index 'toIndex'.
+     *
+     * @param target    a primitive {@code byte} value
+     * @param fromIndex search from this index
+     * @param toIndex   search to this index
+     * @return the least index {@code i} for which {@code array[i] == target}, or
+     * {@code -1} if no such index exists or fromIndex is gt target length.
+     */
+    public int indexOf(byte target, int fromIndex, int toIndex) {
+        return indexOf(new byte[]{target}, fromIndex, toIndex);
+    }
+
+    /**
      * Returns the start position of the first occurrence of the specified {@code
      * target} within {@code array}, or {@code -1} if there is no such occurrence.
      * <p>
@@ -1309,6 +1323,25 @@ public class Bytes implements Comparable<Bytes>, Serializable, Iterable<Byte> {
      */
     public int indexOf(byte[] subArray, int fromIndex) {
         return Util.Byte.indexOf(internalArray(), subArray, fromIndex, length());
+    }
+
+    /**
+     * Returns the start position of the first occurrence of the specified {@code
+     * target} within {@code array} from given start index 'fromIndex' to given end
+     * index 'toIndex', or {@code -1} if there is no such occurrence.
+     * <p>
+     * More formally, returns the lowest index {@code i} such that {@code
+     * java.util.Arrays.copyOfRange(array, i, i + target.length)} contains exactly
+     * the same elements as {@code target}.
+     *
+     * @param subArray  the array to search for as a sub-sequence of {@code array}
+     * @param fromIndex search from this index
+     * @param toIndex search to this index
+     * @return the least index {@code i} for which {@code array[i] == target}, or
+     * {@code -1} if no such index exists.
+     */
+    public int indexOf(byte[] subArray, int fromIndex, int toIndex) {
+        return Util.Byte.indexOf(internalArray(), subArray, fromIndex, toIndex);
     }
 
     /**

--- a/src/test/java/at/favre/lib/bytes/BytesMiscTest.java
+++ b/src/test/java/at/favre/lib/bytes/BytesMiscTest.java
@@ -189,6 +189,15 @@ public class BytesMiscTest extends ABytesTest {
     }
 
     @Test
+    public void indexOfByteFromIndexToIndex() {
+        assertEquals(4, Bytes.from(example_bytes_seven).indexOf((byte) 0x1E, 0, 7));
+        assertEquals(4, Bytes.from(example_bytes_seven).indexOf((byte) 0x1E, 3, 5));
+        assertEquals(-1, Bytes.from(example_bytes_seven).indexOf((byte) 0x1E, 0, 3));
+        assertEquals(-1, Bytes.from(example_bytes_seven).indexOf((byte) 0x1E, 6, 7));
+        assertEquals(-1, Bytes.from(example_bytes_seven).indexOf((byte) 0xCA, 0, 7));
+    }
+
+    @Test
     public void indexOfArray() {
         assertEquals(-1, Bytes.allocate(0).indexOf(new byte[]{(byte) 0xFD}));
         assertEquals(-1, Bytes.allocate(1).indexOf(new byte[0]));
@@ -202,6 +211,16 @@ public class BytesMiscTest extends ABytesTest {
         assertEquals(-1, Bytes.allocate(1).indexOf(new byte[0], 0));
         assertEquals(-1, Bytes.from(example_bytes_seven).indexOf(new byte[]{(byte) 0xFD, (byte) 0xFF}, 8));
         assertEquals(2, Bytes.from(new byte[]{(byte) 0x8E, (byte) 0xD1, (byte) 0x8E, (byte) 0xD1, 0x12, (byte) 0xAF, (byte) 0x78, 0x09, 0x1E, (byte) 0xD1, (byte) 0xFD, (byte) 0xAA, 0x12}).indexOf(new byte[]{(byte) 0x8E, (byte) 0xD1}, 1));
+    }
+
+    @Test
+    public void indexOfArrayFromIndexToIndex() {
+        assertEquals(4, Bytes.from(example_bytes_seven).indexOf(new byte[] { (byte) 0x1E, (byte) 0xAF }, 0, 7));
+        assertEquals(4, Bytes.from(example_bytes_seven).indexOf(new byte[] { (byte) 0x1E, (byte) 0xAF }, 3, 5));
+        assertEquals(4, Bytes.from(example_bytes_seven).indexOf(new byte[] { (byte) 0x1E, (byte) 0xAF, (byte) 0xED }, 4, 5));
+        assertEquals(-1, Bytes.from(example_bytes_seven).indexOf(new byte[] { (byte) 0x1E, (byte) 0xAF }, 0, 3));
+        assertEquals(-1, Bytes.from(example_bytes_seven).indexOf(new byte[] { (byte) 0x1E, (byte) 0xAF }, 6, 7));
+        assertEquals(-1, Bytes.from(example_bytes_seven).indexOf(new byte[] { (byte) 0xCA, (byte) 0xFE }, 0, 7));
     }
 
     @Test


### PR DESCRIPTION
Hi Patrick,
I've had a number of occasions when I found myself in need of a `toIndex` version of `indexOf`. I happen to know particular windows in my byte arrays where the value is supposed to be.  

I'm leveraging existing functionality in `indexOf`, just passing a `toIndex` instead of `length()`. 

What do you think? Could this go into `1.5.1`?

Regards,
Herman.