### PR TITLE
Add module-info via moditect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,13 +81,31 @@
             </plugin>
             <plugin>
               <artifactId>maven-jar-plugin</artifactId>
-              <configuration>
-                  <archive>
-                      <manifestEntries>
-                          <Automatic-Module-Name>at.favre.lib.bytes</Automatic-Module-Name>
-                      </manifestEntries>
-                  </archive>
-              </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Final</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>at.favre.lib.bytes</name>
+                                    <exports>
+                                        at.favre.lib.bytes;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Addresses #63 

Before:

```
> jlink -p target/bytes-1.6.2.jar --add-modules at.favre.lib.bytes --output jre

Error: automatic module cannot be used with jlink: at.favre.lib.bytes from file:///Users/emccue/Development/bytes-java/target/bytes-1.6.2.jar
```

After:

```
> jlink -p target/bytes-1.6.2.jar --add-modules at.favre.lib.bytes --output jre
> ./jre/bin/java --list-modules
at.favre.lib.bytes@1.6.2
java.base@21.0.1
jdk.internal.vm.ci@21.0.1
```